### PR TITLE
Add the  blog post read time

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,14 +2,16 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 import cloudflare from "@astrojs/cloudflare";
+import { remarkReadingTime } from "./integrations/reading-time.mjs";
 
 export default defineConfig({
   site: "https://example.com",
-
+  markdown: {
+    remarkPlugins: [remarkReadingTime]
+  },
   vite: {
       plugins: [tailwindcss()],
 	},
-
   adapter: cloudflare({
     imageService: 'cloudflare',
   }),

--- a/integrations/reading-time.mjs
+++ b/integrations/reading-time.mjs
@@ -1,0 +1,10 @@
+import getReadingTime from 'reading-time';
+import { toString } from 'mdast-util-to-string';
+
+export function remarkReadingTime() {
+  return function (tree, { data }) {
+    const textOnPage = toString(tree);
+    const readingTime = getReadingTime(textOnPage);
+    data.astro.frontmatter.minutesRead = readingTime.text;
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 				"@astrojs/rss": "4.0.11",
 				"@tailwindcss/vite": "^4.1.4",
 				"astro": "^5.7.9",
+				"mdast-util-to-string": "^4.0.0",
+				"reading-time": "^1.5.0",
 				"sharp": "^0.34.1",
 				"tailwindcss": "^4.1.4"
 			},
@@ -5032,6 +5034,12 @@
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
 			}
+		},
+		"node_modules/reading-time": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+			"integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+			"license": "MIT"
 		},
 		"node_modules/regex": {
 			"version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 		"@astrojs/rss": "4.0.11",
 		"@tailwindcss/vite": "^4.1.4",
 		"astro": "^5.7.9",
+		"mdast-util-to-string": "^4.0.0",
+		"reading-time": "^1.5.0",
 		"sharp": "^0.34.1",
 		"tailwindcss": "^4.1.4"
 	},

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<"posts">;
 
 const post = Astro.props;
-const { Content } = await render(post);
+const { Content, remarkPluginFrontmatter } = await render(post);
 const { title, date } = post.data;
 ---
 
@@ -29,10 +29,12 @@ const { title, date } = post.data;
 	>
 		{title}
 	</h1>
-	<p class="mt-4 text-lg text-zinc-450">
-		{date}
+	
+	<p class="mt-4 text-lg text-zinc-450 flex gap-4">
+		<span>{remarkPluginFrontmatter.minutesRead}</span>
+		<span>{date}</span>
 	</p>
-	<div class="mt-12 max-w-none prose">
+	<div class="mt-10 max-w-none prose">
 		<Content />
 	</div>
 </Layout>


### PR DESCRIPTION
This pull request introduces a new feature to display estimated reading time for blog posts on the site. The changes include integrating a reading time calculation plugin, updating the blog page to display the reading time, and adding necessary dependencies.